### PR TITLE
Use getAttributeValue to get the attribute value

### DIFF
--- a/src/Forms/Components/TitleWithSlugInput.php
+++ b/src/Forms/Components/TitleWithSlugInput.php
@@ -120,7 +120,7 @@ class TitleWithSlugInput
             ->slugInputVisitLinkLabel($urlVisitLinkLabel)
             ->slugInputUrlVisitLinkVisible($urlVisitLinkVisible)
             ->slugInputContext(fn ($context) => $context === 'create' ? 'create' : 'edit')
-            ->slugInputRecordSlug(fn (?Model $record) => $record?->$fieldSlug)
+            ->slugInputRecordSlug(fn (?Model $record) => $record?->getAttributeValue($fieldSlug))
             ->slugInputModelName(
                 fn (?Model $record) => $record
                     ? Str::of(class_basename($record))->headline()


### PR DESCRIPTION
My use case is a translated title/slug field, both stored in a JSON column but I believe it applies anytime you try to use a property of a JSON field for the fieldSlug (eg: 'slug.en').
In that case an exception is raised when the SlugInput is readling the attribute value and `Model::preventAccessingMissingAttributes` is enabled.
To fix this we can directly call the `getAttributeValue` method of the model instead of the magic methods.